### PR TITLE
Remove sorting ignored methods from Newspaper Order rule

### DIFF
--- a/src/newspaperOrderRule.ts
+++ b/src/newspaperOrderRule.ts
@@ -150,7 +150,7 @@ abstract class NewspaperHelper {
         const { methodNames, orderedMethodNames } = this;
         return methodNames.filter(methodName => {
             return orderedMethodNames.indexOf(methodName) === -1;
-        }).sort();
+        });
     }
 
     @Memoize


### PR DESCRIPTION
All ignored methods (methods which do not call other methods)
were being alphabetically sorted. This is unnecessary.