### PR TITLE
Fix #37 - feature-envy: Fix static property and method handling

### DIFF
--- a/src/noFeatureEnvyRule.ts
+++ b/src/noFeatureEnvyRule.ts
@@ -187,6 +187,9 @@ class ClassMethodWalker extends Lint.SyntaxWalker {
         if (expression.kind === ts.SyntaxKind.SuperKeyword) {
             return 'this';
         }
+        if (this.classNode.name.getText() === expression.getText()) {
+            return 'this';
+        }
         return expression.getText();
     }
 }


### PR DESCRIPTION
Fixes #37 

Previously, feature-envy treated references to static properties
and methods as references to a foreign class, thus making methods
fail the test when they should actually pass.

Instead, we now check if the accessed property / method is a
static member of the calling method's class and treat it like
a regular property / method.

Also added test cases to check for both passing / failing in the
static property / method contexts.