### PR TITLE
Skip comments starting with NOTE, TODO, etc

### DIFF
--- a/src/noCommentedOutCodeRule.ts
+++ b/src/noCommentedOutCodeRule.ts
@@ -55,6 +55,9 @@ class NoCommentedOutCodeRuleWalker extends ErrorTolerantWalker {
         if (this.textIsTslintFlag(text)) {
             return false;
         }
+        if (this.textIsNote(text)) {
+            return false;
+        }
         const sourceFile = ts.createSourceFile('', text, ts.ScriptTarget.ES5, true);
         if (sourceFile) {
             const { statements } = sourceFile;
@@ -71,6 +74,10 @@ class NoCommentedOutCodeRuleWalker extends ErrorTolerantWalker {
 
     private textIsTslintFlag(text: string): boolean {
         return text.startsWith('tslint:');
+    }
+
+    private textIsNote(text: string): boolean {
+        return /^(NOTE|TODO|FIXME|BUG|HACK|XXX)(\([^:]+\))?:/.test(text);
     }
 
     private cleanComment(text: string): string {

--- a/src/tests/NoCommentedOutCodeRuleTests.ts
+++ b/src/tests/NoCommentedOutCodeRuleTests.ts
@@ -63,6 +63,34 @@ describe('noCommentedOutCodeRule', (): void => {
         TestHelper.assertViolations(ruleName, script, []);
     });
 
+    it('should pass on TODO-like comments', (): void => {
+        const script: string = `
+        // TODO: foo
+        // TODO foo
+        // NOTE: foo
+        // Note: foo
+        // XXX: foo + bar
+        // xxx: foo + bar
+        // FIXME(foo) bar
+        // FIXME(foo): bar
+        // FIXME({foo: bar})
+        `;
+        TestHelper.assertViolations(ruleName, script, [
+            noCommentedOutCodeError({
+                character: 9,
+                line: 5,
+            }),
+            noCommentedOutCodeError({
+                character: 9,
+                line: 7,
+            }),
+            noCommentedOutCodeError({
+                character: 9,
+                line: 10,
+            }),
+        ]);
+    });
+
     it('should pass on code with inline comments', (): void => {
         const script: string = `
         const obj = {
@@ -90,16 +118,20 @@ describe('noCommentedOutCodeRule', (): void => {
         `;
 
         TestHelper.assertViolations(ruleName, script, [
-            {
-                failure: 'No commented out code.',
-                name: 'file.ts',
-                ruleName: 'no-commented-out-code',
-                ruleSeverity: 'ERROR',
-                startPosition: {
-                    character: 13,
-                    line: 2,
-                },
-            },
+            noCommentedOutCodeError({
+                character: 13,
+                line: 2,
+            }),
         ]);
     });
 });
+
+function noCommentedOutCodeError(startPosition: TestHelper.FailurePosition): TestHelper.ExpectedFailure {
+    return {
+        failure: 'No commented out code.',
+        name: 'file.ts',
+        ruleName: 'no-commented-out-code',
+        ruleSeverity: 'ERROR',
+        startPosition,
+    }
+}


### PR DESCRIPTION
Recognizes `// NOTE: foo`, `// TODO foo`, and `FIXME(bobby): foo`

I ran into this when my `TODO:` comment only had one word after it.