### PR TITLE
Fix single word in block comments for no-commented-out-code

### DIFF
--- a/src/noCommentedOutCodeRule.ts
+++ b/src/noCommentedOutCodeRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: 'Code must not be commented out.',
         options: null,
         optionsDescription: '',
-        optionExamples: [], //Remove this property if the rule has no options
+        optionExamples: [], // Remove this property if the rule has no options
         typescriptOnly: false,
         issueClass: 'Non-SDL', // one of: 'SDL' | 'Non-SDL' | 'Ignored'
         issueType: 'Warning', // one of: 'Error' | 'Warning'
@@ -81,8 +81,8 @@ class NoCommentedOutCodeRuleWalker extends ErrorTolerantWalker {
     }
 
     private isTextSingleWord(text: string): boolean {
-        const pattern = new RegExp('^[\\w-]*$');
-        return pattern.test(text);
+        const pattern = new RegExp('^([\\w-]*)$');
+        return pattern.test(text.trim());
     }
 
     /**

--- a/src/tests/NoCommentedOutCodeRuleTests.ts
+++ b/src/tests/NoCommentedOutCodeRuleTests.ts
@@ -6,16 +6,17 @@ import { TestHelper } from './TestHelper';
 describe('noCommentedOutCodeRule', (): void => {
     const ruleName: string = 'no-commented-out-code';
 
-    it('should pass on single word', (): void => {
-        const script: string = `
+    context('when inside inline comment', (): void => {
+        it('should pass on single word', (): void => {
+            const script: string = `
             // lorem
-        `;
+            `;
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-    it('should pass on inline comment', (): void => {
-        const script: string = `
+        it('should pass on multiple words', (): void => {
+            const script: string = `
             // Lorem ipsum dolor sit
 
             const obj = {
@@ -25,71 +26,97 @@ describe('noCommentedOutCodeRule', (): void => {
                 // Lorem ipsum dolor sit
                 baz: true
             }
-        `;
+            `;
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-    it('should fail on commented-out code with inline comment', (): void => {
-        const script: string = `
+        it('should fail on commented-out code', (): void => {
+            const script: string = `
             // console.log("Lorem ipsum");
-        `;
+            `;
 
-        TestHelper.assertViolations(ruleName, script, [
-            noCommentedOutCodeError({
-                character: 13,
-                line: 2,
-            }),
-        ]);
+            TestHelper.assertViolations(ruleName, script, [
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 2,
+                }),
+            ]);
+        });
     });
 
-    it('should pass on block comments', (): void => {
-        const script: string = `
+    context('when inside block comment', (): void => {
+        it('should pass on single word', (): void => {
+            const script: string = `
             /*
-                Lorem ipsum dolor sit
+            lorem
             */
 
-            /* Lorem ipsum dolor sit */
+           /* lorem */
         `;
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+        it('should pass on multiple words', (): void => {
+            const script: string = `
+            /*
+            Lorem ipsum dolor sit
+            */
 
-    it('should fail on commented-out code with block comments', (): void => {
-        const script: string = `
+           /* Lorem ipsum dolor sit */
+           `;
+
+            TestHelper.assertNoViolation(ruleName, script);
+        });
+
+        it('should fail on commented-out code', (): void => {
+            const script: string = `
             /*
             console.log("Lorem ipsum");
             */
 
             /* console.log("Lorem ipsum"); */
-        `;
+            `;
 
-        TestHelper.assertViolations(ruleName, script, [
-            noCommentedOutCodeError({
-                character: 13,
-                line: 2,
-            }),
-            noCommentedOutCodeError({
-                character: 13,
-                line: 6,
-            }),
-        ]);
+            TestHelper.assertViolations(ruleName, script, [
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 2,
+                }),
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 6,
+                }),
+            ]);
+        });
     });
 
-    it('should pass on JSDoc-style block comment', (): void => {
-        const script: string = `
+    context('when inside JSDoc-style block comment', (): void => {
+        it('should pass on single word', (): void => {
+            const script: string = `
             /**
+             * lorem
+             */
+
+            /** lorem */
+            `;
+            TestHelper.assertNoViolation(ruleName, script);
+        });
+
+        it('should pass on multiple words', (): void => {
+            const script: string = `
+             /**
              *  Lorem ipsum dolor sit
              */
 
             /** Lorem ipsum dolor sit */
-        `;
+            `;
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-    it('should pass on JSDoc with tags', (): void => {
-        const script: string = `
+        it('should pass on JSDoc with tags', (): void => {
+            const script: string = `
             /**
              * @constructor
              */
@@ -109,11 +136,11 @@ describe('noCommentedOutCodeRule', (): void => {
              */
         `;
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-    it('should fail on commented-out code with JSDoc-style block comment', (): void => {
-        const script: string = `
+        it('should fail on commented-out code', (): void => {
+            const script: string = `
             /**
              * console.log("Lorem ipsum");
              */
@@ -121,49 +148,53 @@ describe('noCommentedOutCodeRule', (): void => {
             /** console.log("Lorem ipsum"); */
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
-            noCommentedOutCodeError({
-                character: 13,
-                line: 2,
-            }),
-            noCommentedOutCodeError({
-                character: 13,
-                line: 6,
-            }),
-        ]);
+            TestHelper.assertViolations(ruleName, script, [
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 2,
+                }),
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 6,
+                }),
+            ]);
+        });
     });
 
-    it('should pass on tslint:disable comment', (): void => {
-        const script: string = `
+    context('when tslint comment', (): void => {
+        it('should pass on tslint:disable comment', (): void => {
+            const script: string = `
             // tslint:disable:no-reserved-keywords
-        `;
+            `;
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-    it('should pass on tslint:enable comment', (): void => {
-        const script: string = `
+        it('should pass on tslint:enable comment', (): void => {
+            const script: string = `
             // tslint:enable:no-reserved-keywords
-        `;
+            `;
 
-        TestHelper.assertNoViolation(ruleName, script);
+            TestHelper.assertNoViolation(ruleName, script);
+        });
     });
 
-    it('should allow commenting-out code if prefixed with uppercase TODO-like note', (): void => {
-        const script: string = `
+    context('when comment contains TODO-like note', (): void => {
+        it('should allow commenting-out code if prefixed with uppercase TODO-like note', (): void => {
+            const script: string = `
             // TODO: a + b
             // NOTE: a + b
             // FIXME: a + b
             // BUG: a + b
             // HACK: a + b
             // XXX: a + b
-        `;
+            `;
 
-        TestHelper.assertNoViolation(ruleName, script);
-    });
+            TestHelper.assertNoViolation(ruleName, script);
+        });
 
-    it('should validate as usual if prefixed with unexpected TODO-like note', (): void => {
-        const script: string = `
+        it('should validate as usual if prefixed with unexpected TODO-like note', (): void => {
+            const script: string = `
             // todo: a + b
             // ToDo: a + b
             // Foo: a + b
@@ -175,22 +206,23 @@ describe('noCommentedOutCodeRule', (): void => {
             // TODO(foo): a + b
             // TODO({foo: "bar"}) a + b
             // TODO({foo: "bar"}): a + b
-        `;
+            `;
 
-        TestHelper.assertViolations(ruleName, script, [
-            noCommentedOutCodeError({
-                character: 13,
-                line: 2,
-            }),
-            noCommentedOutCodeError({
-                character: 13,
-                line: 3,
-            }),
-            noCommentedOutCodeError({
-                character: 13,
-                line: 4,
-            }),
-        ]);
+            TestHelper.assertViolations(ruleName, script, [
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 2,
+                }),
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 3,
+                }),
+                noCommentedOutCodeError({
+                    character: 13,
+                    line: 4,
+                }),
+            ]);
+        });
     });
 });
 


### PR DESCRIPTION
Fixes https://github.com/Glavin001/tslint-clean-code/pull/62/files#r229909418
As reported by @stevenzeck in https://github.com/Unibeautify/unibeautify/pull/207#issuecomment-433951732
